### PR TITLE
feat: Implement CVF Open Access PDF collector (#87)

### DIFF
--- a/journals/cvf_implementation_complete.md
+++ b/journals/cvf_implementation_complete.md
@@ -1,0 +1,50 @@
+# CVF Open Access Scraper Implementation Complete - Issue #87
+
+## Timestamp: 2025-07-02 @ 15:00
+
+### Analysis Request
+Complete implementation of issue #87 - CVF Open Access Scraper following TDD with coverage requirements.
+
+### Implementation Summary
+
+Successfully implemented the CVF Open Access PDF collector within the 2-3 hour time estimate. The implementation follows all established patterns and integrates seamlessly with the existing PDF discovery framework.
+
+### Key Components Delivered
+
+1. **CVFCollector Class** (`src/pdf_discovery/sources/cvf_collector.py`):
+   - Inherits from `BasePDFCollector`
+   - Supports CVPR, ICCV, ECCV, and WACV conferences
+   - Implements proceedings page parsing with fuzzy title matching (85% threshold)
+   - Handles biannual conference validation (ICCV-odd years, ECCV-even years)
+   - Includes caching for proceedings pages to optimize performance
+
+2. **Test Coverage** (99%):
+   - 13 unit tests covering all functionality
+   - 3 integration tests demonstrating framework usage
+   - Tests mock HTTP requests and validate all edge cases
+
+3. **Integration**:
+   - Added to `__init__.py` exports
+   - Ready to use with `framework.add_collector(CVFCollector())`
+
+### Technical Highlights
+
+- **URL Pattern**: Correctly constructs `https://openaccess.thecvf.com/{venue}{year}/papers/{paper_id}.pdf`
+- **Title Matching**: Uses rapidfuzz for robust fuzzy matching of paper titles
+- **Error Handling**: Graceful handling of network errors and missing papers
+- **Performance**: Caches proceedings pages to avoid redundant HTTP requests
+
+### Testing Results
+```
+16 passed in 0.59s
+Coverage: 99% (85 statements, 1 missed)
+```
+
+### Pull Request
+Created PR #119: https://github.com/bouthilx/compute-forecast/pull/119
+
+### Outcome
+✅ Issue #87 successfully completed within time budget
+✅ All acceptance criteria met
+✅ Code quality standards maintained
+✅ Ready for review and merge

--- a/journals/cvf_scraper_planning.md
+++ b/journals/cvf_scraper_planning.md
@@ -1,0 +1,53 @@
+# CVF Open Access Scraper Planning - Issue #87
+
+## Timestamp: 2025-07-02 @ 14:30
+
+### Analysis Request
+Plan implementation of issue #87 (CVF Open Access Scraper) and verify codebase readiness.
+
+### Investigation Process
+
+1. **Issue Details**: 
+   - Implement scraper for CVF Open Access (CVPR, ICCV, ECCV conferences)
+   - URL Pattern: `https://openaccess.thecvf.com/{venue}{year}/papers/{paper}.pdf`
+   - Dependencies: #77 (PDF Framework) and #78 (Deduplication) - both CLOSED
+   - Time estimate: S (2-3h)
+
+2. **Codebase Analysis**:
+   - PDF Discovery Framework exists at `src/pdf_discovery/core/`
+   - Base collector interface (`BasePDFCollector`) provides required abstraction
+   - Several collectors already implemented (PMLR, OpenReview, etc.) serve as patterns
+   - NO existing CVF collector found
+
+3. **Required Components Status**:
+   - ✅ `BasePDFCollector` abstract class with `_discover_single()` method
+   - ✅ `PDFRecord` data model for storing PDF metadata
+   - ✅ Framework orchestration supporting parallel collectors
+   - ✅ Venue database includes CVF conferences (CVPR, ICCV, ECCV)
+   - ❌ CVF-specific collector implementation
+
+### Implementation Plan
+
+1. **Create CVF Collector** (`src/pdf_discovery/sources/cvf_collector.py`):
+   - Inherit from `BasePDFCollector`
+   - Source name: "cvf"
+   - Confidence score: ~0.95 (direct source)
+
+2. **Core Implementation**:
+   - Map venue names to CVF format (e.g., "CVPR" → "CVPR", "ICCV" → "ICCV")
+   - Construct proceedings URL for venue+year
+   - Parse proceedings page to find paper by title match
+   - Extract paper ID from proceedings
+   - Build final PDF URL
+
+3. **Key Methods**:
+   - `_discover_single(paper: Paper) -> PDFRecord`
+   - Helper methods for URL construction and title matching
+
+4. **Testing Strategy**:
+   - Unit tests for URL construction
+   - Mock tests for proceedings parsing
+   - Integration test with sample papers
+
+### Outcome
+All dependencies are satisfied and the codebase is ready for CVF collector implementation. The pattern is well-established from existing collectors, making this a straightforward implementation task within the 2-3 hour estimate.

--- a/package/src/pdf_discovery/sources/__init__.py
+++ b/package/src/pdf_discovery/sources/__init__.py
@@ -6,6 +6,7 @@ from .pmlr_collector import PMLRCollector
 from .pubmed_central_collector import PubMedCentralCollector
 from .acl_anthology_collector import ACLAnthologyCollector
 from .openalex_collector import OpenAlexPDFCollector
+from .cvf_collector import CVFCollector
 
 __all__ = [
     "OpenReviewPDFCollector",
@@ -15,5 +16,6 @@ __all__ = [
     "PMLRCollector",
     "PubMedCentralCollector",
     "ACLAnthologyCollector",
-    "OpenAlexPDFCollector"
+    "OpenAlexPDFCollector",
+    "CVFCollector"
 ]

--- a/package/src/pdf_discovery/sources/cvf_collector.py
+++ b/package/src/pdf_discovery/sources/cvf_collector.py
@@ -1,0 +1,208 @@
+"""CVF Open Access PDF collector for computer vision conferences."""
+
+import logging
+import re
+from datetime import datetime
+from typing import Optional, Dict, Tuple
+from urllib.parse import urljoin
+
+import requests
+from bs4 import BeautifulSoup
+from rapidfuzz import fuzz
+
+from src.pdf_discovery.core.collectors import BasePDFCollector
+from src.pdf_discovery.core.models import PDFRecord
+from src.data.models import Paper
+
+logger = logging.getLogger(__name__)
+
+
+class CVFCollector(BasePDFCollector):
+    """Collector for Computer Vision Foundation open access papers."""
+    
+    # Class constants
+    FUZZY_MATCH_THRESHOLD = 85
+    REQUEST_TIMEOUT = 30
+    CONFIDENCE_SCORE = 0.95
+    
+    def __init__(self):
+        """Initialize CVF collector."""
+        super().__init__("cvf")
+        self.base_url = "https://openaccess.thecvf.com/"
+        self.supported_venues = ["CVPR", "ICCV", "ECCV", "WACV"]
+        
+        # Conference schedules
+        self.venue_schedules = {
+            "CVPR": "annual",      # Every year
+            "ICCV": "biannual_odd", # Odd years only (2019, 2021, 2023...)
+            "ECCV": "biannual_even", # Even years only (2020, 2022, 2024...)
+            "WACV": "annual"       # Every year
+        }
+        
+        # Cache for proceedings pages to avoid repeated fetches
+        self._proceedings_cache: Dict[Tuple[str, int], str] = {}
+        
+        # Configure timeout for HTTP requests
+        self.request_timeout = self.REQUEST_TIMEOUT
+    
+    def _validate_venue_year(self, venue: str, year: int) -> bool:
+        """Validate if a conference occurs in a given year.
+        
+        Args:
+            venue: Conference name
+            year: Publication year
+            
+        Returns:
+            True if the conference occurs in that year
+        """
+        schedule = self.venue_schedules.get(venue, "annual")
+        
+        if schedule == "annual":
+            return True
+        elif schedule == "biannual_odd":
+            return year % 2 == 1
+        elif schedule == "biannual_even":
+            return year % 2 == 0
+        
+        return True
+    
+    def _construct_proceedings_url(self, venue: str, year: int) -> str:
+        """Construct proceedings URL for a venue and year.
+        
+        Args:
+            venue: Conference name (e.g., "CVPR")
+            year: Conference year
+            
+        Returns:
+            Full proceedings URL
+        """
+        return urljoin(self.base_url, f"{venue}{year}")
+    
+    def _construct_pdf_url(self, venue: str, year: int, paper_id: str) -> str:
+        """Construct PDF URL from components.
+        
+        Args:
+            venue: Conference name
+            year: Conference year
+            paper_id: Paper identifier from proceedings
+            
+        Returns:
+            Full PDF URL
+        """
+        return urljoin(self.base_url, f"{venue}{year}/papers/{paper_id}.pdf")
+    
+    def _search_proceedings_page(self, venue: str, year: int, paper_title: str) -> Optional[str]:
+        """Search proceedings page for paper by title.
+        
+        Args:
+            venue: Conference name
+            year: Conference year
+            paper_title: Title to search for
+            
+        Returns:
+            Paper ID if found, None otherwise
+        """
+        cache_key = (venue, year)
+        
+        # Fetch proceedings page (use cache if available)
+        if cache_key not in self._proceedings_cache:
+            proceedings_url = self._construct_proceedings_url(venue, year)
+            
+            try:
+                response = requests.get(proceedings_url, timeout=self.request_timeout)
+                response.raise_for_status()
+                self._proceedings_cache[cache_key] = response.text
+                logger.info(f"Fetched CVF proceedings for {venue}{year}")
+            except requests.RequestException as e:
+                logger.error(f"Failed to fetch CVF proceedings for {venue}{year}: {e}")
+                return None
+        
+        # Parse proceedings HTML
+        html_content = self._proceedings_cache[cache_key]
+        soup = BeautifulSoup(html_content, 'html.parser')
+        
+        # Find all paper links
+        # CVF uses pattern: /content/{venue}{year}/papers/{paper_id}.pdf
+        pdf_pattern = re.compile(rf'/content/{venue}{year}/papers/([^/]+)\.pdf')
+        
+        papers_found = []
+        
+        # Look for all links to PDFs
+        for link in soup.find_all('a', href=pdf_pattern):
+            href = link.get('href', '')
+            match = pdf_pattern.search(href)
+            if match:
+                paper_id = match.group(1)
+                # Get the link text as title
+                link_title = link.get_text(strip=True)
+                if link_title:
+                    papers_found.append((paper_id, link_title))
+        
+        if not papers_found:
+            logger.warning(f"No papers found in {venue}{year} proceedings")
+            return None
+        
+        # Find best title match
+        best_match = None
+        best_score = 0
+        
+        for paper_id, found_title in papers_found:
+            # Calculate fuzzy match score
+            score = fuzz.ratio(paper_title.lower(), found_title.lower())
+            
+            if score > best_score:
+                best_score = score
+                best_match = paper_id
+        
+        # Return if score is above threshold
+        if best_score >= self.FUZZY_MATCH_THRESHOLD:
+            logger.info(f"Found paper '{paper_title}' with score {best_score}")
+            return best_match
+        
+        logger.warning(f"No match found for '{paper_title}' (best score: {best_score})")
+        return None
+    
+    def _discover_single(self, paper: Paper) -> PDFRecord:
+        """Discover PDF for a single paper.
+        
+        Args:
+            paper: Paper to find PDF for
+            
+        Returns:
+            PDFRecord with discovered PDF information
+            
+        Raises:
+            ValueError: If PDF cannot be discovered
+        """
+        # Check if venue is supported
+        if paper.venue not in self.supported_venues:
+            raise ValueError(f"Venue '{paper.venue}' is not a CVF venue. Supported: {self.supported_venues}")
+        
+        # Validate venue/year combination
+        if not self._validate_venue_year(paper.venue, paper.year):
+            raise ValueError(f"{paper.venue} does not occur in {paper.year}")
+        
+        # Search proceedings for paper
+        paper_id = self._search_proceedings_page(paper.venue, paper.year, paper.title)
+        
+        if not paper_id:
+            raise ValueError(f"Could not find paper '{paper.title}' in {paper.venue}{paper.year} proceedings")
+        
+        # Construct PDF URL
+        pdf_url = self._construct_pdf_url(paper.venue, paper.year, paper_id)
+        
+        # Create and return PDF record
+        return PDFRecord(
+            paper_id=paper.paper_id,
+            pdf_url=pdf_url,
+            source=self.source_name,
+            discovery_timestamp=datetime.now(),
+            confidence_score=self.CONFIDENCE_SCORE,
+            version_info={
+                "venue": paper.venue,
+                "year": paper.year,
+                "cvf_paper_id": paper_id
+            },
+            validation_status="validated",
+            license="CVF Open Access"
+        )

--- a/package/tests/integration/pdf_discovery/test_cvf_integration.py
+++ b/package/tests/integration/pdf_discovery/test_cvf_integration.py
@@ -1,0 +1,181 @@
+"""Integration tests for CVF collector with PDF discovery framework."""
+
+import pytest
+from unittest.mock import patch, Mock
+
+from src.pdf_discovery import PDFDiscoveryFramework
+from src.pdf_discovery.sources import CVFCollector
+from src.data.models import Paper
+
+
+class TestCVFIntegration:
+    """Integration tests for CVF collector."""
+    
+    @pytest.fixture
+    def framework(self):
+        """Create framework with CVF collector."""
+        framework = PDFDiscoveryFramework()
+        framework.add_collector(CVFCollector())
+        return framework
+    
+    @pytest.fixture
+    def cvf_papers(self):
+        """Create sample CVF conference papers."""
+        return [
+            Paper(
+                paper_id="cvpr_2023_1",
+                title="Deep Learning for Object Detection",
+                authors=["John Doe", "Jane Smith"],
+                year=2023,
+                citations=50,
+                venue="CVPR"
+            ),
+            Paper(
+                paper_id="iccv_2023_1",
+                title="Vision Transformers for Image Classification",
+                authors=["Alice Brown"],
+                year=2023,
+                citations=30,
+                venue="ICCV"
+            ),
+            Paper(
+                paper_id="eccv_2022_1",
+                title="Neural Rendering Techniques",
+                authors=["Bob Wilson"],
+                year=2022,
+                citations=25,
+                venue="ECCV"
+            ),
+            Paper(
+                paper_id="icml_2023_1",
+                title="Machine Learning Theory",
+                authors=["Charlie Davis"],
+                year=2023,
+                citations=40,
+                venue="ICML"  # Not a CVF venue
+            )
+        ]
+    
+    @patch('requests.get')
+    def test_framework_discovery_with_cvf(self, mock_get, framework, cvf_papers):
+        """Test PDF discovery through framework with CVF collector."""
+        # Mock successful proceedings fetch for each venue
+        def mock_response(url, **kwargs):
+            response = Mock()
+            response.status_code = 200
+            
+            if "CVPR2023" in url:
+                response.text = '''
+                <html><body>
+                <a href="/content/CVPR2023/papers/Doe23_Deep_Learning_Object_Detection_CVPR_2023_paper.pdf">
+                    Deep Learning for Object Detection
+                </a>
+                </body></html>
+                '''
+            elif "ICCV2023" in url:
+                response.text = '''
+                <html><body>
+                <a href="/content/ICCV2023/papers/Brown23_Vision_Transformers_ICCV_2023_paper.pdf">
+                    Vision Transformers for Image Classification
+                </a>
+                </body></html>
+                '''
+            elif "ECCV2022" in url:
+                response.text = '''
+                <html><body>
+                <a href="/content/ECCV2022/papers/Wilson22_Neural_Rendering_ECCV_2022_paper.pdf">
+                    Neural Rendering Techniques
+                </a>
+                </body></html>
+                '''
+            else:
+                response.text = '<html><body>No papers</body></html>'
+            
+            return response
+        
+        mock_get.side_effect = mock_response
+        
+        # Run discovery
+        result = framework.discover_pdfs(cvf_papers)
+        
+        # Verify results
+        assert result.total_papers == 4
+        assert result.discovered_count == 3  # 3 CVF papers found
+        assert len(result.records) == 3
+        assert len(result.failed_papers) == 1
+        assert "icml_2023_1" in result.failed_papers
+        
+        # Check discovered PDFs
+        pdf_by_id = {r.paper_id: r for r in result.records}
+        
+        # CVPR paper
+        assert "cvpr_2023_1" in pdf_by_id
+        cvpr_pdf = pdf_by_id["cvpr_2023_1"]
+        assert cvpr_pdf.source == "cvf"
+        assert "CVPR2023/papers/Doe23_Deep_Learning_Object_Detection_CVPR_2023_paper.pdf" in cvpr_pdf.pdf_url
+        assert cvpr_pdf.confidence_score == 0.95
+        
+        # ICCV paper
+        assert "iccv_2023_1" in pdf_by_id
+        iccv_pdf = pdf_by_id["iccv_2023_1"]
+        assert "ICCV2023/papers/Brown23_Vision_Transformers_ICCV_2023_paper.pdf" in iccv_pdf.pdf_url
+        
+        # ECCV paper
+        assert "eccv_2022_1" in pdf_by_id
+        eccv_pdf = pdf_by_id["eccv_2022_1"]
+        assert "ECCV2022/papers/Wilson22_Neural_Rendering_ECCV_2022_paper.pdf" in eccv_pdf.pdf_url
+    
+    def test_cvf_venue_priority(self, framework):
+        """Test that CVF collector can be prioritized for CV venues."""
+        # Set CVF as priority for computer vision conferences
+        framework.set_venue_priorities({
+            "CVPR": ["cvf", "semantic_scholar"],
+            "ICCV": ["cvf", "semantic_scholar"],
+            "ECCV": ["cvf", "semantic_scholar"],
+            "WACV": ["cvf", "semantic_scholar"]
+        })
+        
+        # Verify priorities were set
+        assert framework.venue_priorities["CVPR"][0] == "cvf"
+        assert framework.venue_priorities["ICCV"][0] == "cvf"
+    
+    @patch('requests.get')
+    def test_cvf_biannual_conference_validation(self, mock_get, framework):
+        """Test that biannual conferences are validated correctly."""
+        # ICCV should work for odd years
+        paper_2023 = Paper(
+            paper_id="test1",
+            title="Test Paper",
+            authors=[],
+            year=2023,
+            citations=0,
+            venue="ICCV"
+        )
+        
+        # ICCV should fail for even years
+        paper_2022 = Paper(
+            paper_id="test2",
+            title="Test Paper",
+            authors=[],
+            year=2022,
+            citations=0,
+            venue="ICCV"
+        )
+        
+        # Mock proceedings
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.text = '''
+        <html><body>
+        <a href="/content/ICCV2023/papers/Test_Paper_ICCV_2023_paper.pdf">Test Paper</a>
+        </body></html>
+        '''
+        mock_get.return_value = mock_response
+        
+        # Test discovery
+        result = framework.discover_pdfs([paper_2023, paper_2022])
+        
+        # Should only find the 2023 paper
+        assert result.discovered_count == 1
+        assert result.records[0].paper_id == "test1"
+        assert "test2" in result.failed_papers

--- a/package/tests/unit/pdf_discovery/test_cvf_collector.py
+++ b/package/tests/unit/pdf_discovery/test_cvf_collector.py
@@ -1,0 +1,274 @@
+"""Unit tests for CVF Open Access PDF collector."""
+
+import pytest
+from unittest.mock import Mock, patch
+from datetime import datetime
+from requests.exceptions import RequestException
+
+from src.pdf_discovery.sources.cvf_collector import CVFCollector
+from src.pdf_discovery.core.models import PDFRecord
+from src.data.models import Paper
+
+
+class TestCVFCollector:
+    """Test suite for CVF collector."""
+    
+    @pytest.fixture
+    def collector(self):
+        """Create CVF collector instance."""
+        return CVFCollector()
+    
+    @pytest.fixture
+    def sample_paper(self):
+        """Create sample paper for testing."""
+        return Paper(
+            paper_id="test_paper_1",
+            title="Deep Learning for Computer Vision",
+            authors=["Author One", "Author Two"],
+            year=2023,
+            citations=10,
+            venue="CVPR"
+        )
+    
+    def test_initialization(self, collector):
+        """Test collector initialization."""
+        assert collector.source_name == "cvf"
+        assert collector.timeout == 60
+        assert collector.base_url == "https://openaccess.thecvf.com/"
+        assert collector.supported_venues == ["CVPR", "ICCV", "ECCV", "WACV"]
+    
+    def test_venue_not_supported(self, collector):
+        """Test handling of unsupported venues."""
+        paper = Paper(
+            paper_id="test_1",
+            title="Test Paper",
+            authors=[],
+            year=2023,
+            citations=0,
+            venue="ICML"  # Not a CVF venue
+        )
+        
+        with pytest.raises(ValueError, match="not a CVF venue"):
+            collector._discover_single(paper)
+    
+    def test_construct_proceedings_url(self, collector):
+        """Test proceedings URL construction."""
+        # Test CVPR
+        url = collector._construct_proceedings_url("CVPR", 2023)
+        assert url == "https://openaccess.thecvf.com/CVPR2023"
+        
+        # Test ICCV
+        url = collector._construct_proceedings_url("ICCV", 2021)
+        assert url == "https://openaccess.thecvf.com/ICCV2021"
+        
+        # Test ECCV
+        url = collector._construct_proceedings_url("ECCV", 2022)
+        assert url == "https://openaccess.thecvf.com/ECCV2022"
+    
+    def test_construct_pdf_url(self, collector):
+        """Test PDF URL construction."""
+        url = collector._construct_pdf_url("CVPR", 2023, "Smith23_Deep_Learning")
+        expected = "https://openaccess.thecvf.com/CVPR2023/papers/Smith23_Deep_Learning.pdf"
+        assert url == expected
+    
+    @patch('requests.get')
+    def test_search_proceedings_success(self, mock_get, collector):
+        """Test successful proceedings page search."""
+        # Mock proceedings HTML with paper links
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.text = '''
+        <html>
+        <body>
+            <div class="paper">
+                <a href="/content/CVPR2023/papers/Smith23_Deep_Learning_for_Computer_Vision_CVPR_2023_paper.pdf">
+                    Deep Learning for Computer Vision
+                </a>
+            </div>
+            <div class="paper">
+                <a href="/content/CVPR2023/papers/Jones23_Other_Paper_CVPR_2023_paper.pdf">
+                    Other Paper Title
+                </a>
+            </div>
+        </body>
+        </html>
+        '''
+        mock_get.return_value = mock_response
+        
+        paper_id = collector._search_proceedings_page("CVPR", 2023, "Deep Learning for Computer Vision")
+        assert paper_id == "Smith23_Deep_Learning_for_Computer_Vision_CVPR_2023_paper"
+    
+    @patch('requests.get')
+    def test_search_proceedings_fuzzy_match(self, mock_get, collector):
+        """Test fuzzy title matching in proceedings."""
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.text = '''
+        <html>
+        <body>
+            <div class="paper">
+                <a href="/content/CVPR2023/papers/Smith23_Deep_Learning_Computer_Vision_CVPR_2023_paper.pdf">
+                    Deep Learning for Computer Vision: A Survey
+                </a>
+            </div>
+        </body>
+        </html>
+        '''
+        mock_get.return_value = mock_response
+        
+        # Should match despite slight title difference
+        paper_id = collector._search_proceedings_page("CVPR", 2023, "Deep Learning for Computer Vision")
+        assert paper_id == "Smith23_Deep_Learning_Computer_Vision_CVPR_2023_paper"
+    
+    @patch('requests.get')
+    def test_search_proceedings_not_found(self, mock_get, collector):
+        """Test when paper is not found in proceedings."""
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.text = '''
+        <html>
+        <body>
+            <div class="paper">
+                <a href="/content/CVPR2023/papers/Other_Paper.pdf">
+                    Completely Different Paper
+                </a>
+            </div>
+        </body>
+        </html>
+        '''
+        mock_get.return_value = mock_response
+        
+        result = collector._search_proceedings_page("CVPR", 2023, "Deep Learning for Computer Vision")
+        assert result is None
+    
+    @patch('requests.get')
+    def test_search_proceedings_network_error(self, mock_get, collector):
+        """Test handling of network errors."""
+        mock_get.side_effect = RequestException("Network error")
+        
+        result = collector._search_proceedings_page("CVPR", 2023, "Test Paper")
+        assert result is None
+    
+    @patch.object(CVFCollector, '_search_proceedings_page')
+    def test_discover_single_success(self, mock_search, collector, sample_paper):
+        """Test successful PDF discovery."""
+        mock_search.return_value = "Smith23_Deep_Learning_CVPR_2023_paper"
+        
+        result = collector._discover_single(sample_paper)
+        
+        assert isinstance(result, PDFRecord)
+        assert result.paper_id == "test_paper_1"
+        assert result.pdf_url == "https://openaccess.thecvf.com/CVPR2023/papers/Smith23_Deep_Learning_CVPR_2023_paper.pdf"
+        assert result.source == "cvf"
+        assert result.confidence_score == 0.95
+        assert result.validation_status == "validated"
+        assert result.license == "CVF Open Access"
+        
+        mock_search.assert_called_once_with("CVPR", 2023, "Deep Learning for Computer Vision")
+    
+    @patch.object(CVFCollector, '_search_proceedings_page')
+    def test_discover_single_paper_not_found(self, mock_search, collector, sample_paper):
+        """Test when paper cannot be found in proceedings."""
+        mock_search.return_value = None
+        
+        with pytest.raises(ValueError, match="Could not find paper"):
+            collector._discover_single(sample_paper)
+    
+    def test_discover_multiple_papers(self, collector):
+        """Test batch discovery of papers."""
+        papers = [
+            Paper(
+                paper_id="p1",
+                title="Paper One",
+                authors=[],
+                year=2023,
+                citations=0,
+                venue="CVPR"
+            ),
+            Paper(
+                paper_id="p2",
+                title="Paper Two",
+                authors=[],
+                year=2023,
+                citations=0,
+                venue="ICML"  # Not CVF
+            ),
+            Paper(
+                paper_id="p3",
+                title="Paper Three",
+                authors=[],
+                year=2022,
+                citations=0,
+                venue="ECCV"
+            )
+        ]
+        
+        with patch.object(collector, '_discover_single') as mock_discover:
+            # Configure mock to succeed for CVF papers, fail for others
+            def side_effect(paper):
+                if paper.venue in ["CVPR", "ECCV"]:
+                    return PDFRecord(
+                        paper_id=paper.paper_id,
+                        pdf_url=f"https://cvf.com/{paper.paper_id}.pdf",
+                        source="cvf",
+                        discovery_timestamp=datetime.now(),
+                        confidence_score=0.95,
+                        version_info={},
+                        validation_status="validated"
+                    )
+                raise ValueError("Not CVF")
+            
+            mock_discover.side_effect = side_effect
+            
+            results = collector.discover_pdfs(papers)
+            
+            assert len(results) == 2
+            assert "p1" in results
+            assert "p3" in results
+            assert "p2" not in results
+    
+    def test_venue_year_validation(self, collector):
+        """Test validation of venue and year combinations."""
+        # ICCV is biannual (odd years)
+        paper_odd = Paper(
+            paper_id="test1",
+            title="Test",
+            authors=[],
+            year=2023,
+            citations=0,
+            venue="ICCV"
+        )
+        
+        paper_even = Paper(
+            paper_id="test2",
+            title="Test",
+            authors=[],
+            year=2022,
+            citations=0,
+            venue="ICCV"
+        )
+        
+        # Should work for odd year
+        with patch.object(collector, '_search_proceedings_page', return_value="paper_id"):
+            result = collector._discover_single(paper_odd)
+            assert result is not None
+        
+        # Should fail for even year
+        with pytest.raises(ValueError, match="does not occur in"):
+            collector._discover_single(paper_even)
+    
+    def test_proceedings_cache(self, collector):
+        """Test that proceedings pages are cached."""
+        with patch('requests.get') as mock_get:
+            mock_response = Mock()
+            mock_response.status_code = 200
+            mock_response.text = '<html><body></body></html>'
+            mock_get.return_value = mock_response
+            
+            # First call
+            collector._search_proceedings_page("CVPR", 2023, "Paper 1")
+            # Second call with same venue/year
+            collector._search_proceedings_page("CVPR", 2023, "Paper 2")
+            
+            # Should only fetch once due to caching
+            assert mock_get.call_count == 1


### PR DESCRIPTION
## Summary
- Implemented CVF Open Access scraper for computer vision conference papers (CVPR, ICCV, ECCV, WACV)
- Added comprehensive test coverage (99%) following TDD principles
- Integrated with existing PDF discovery framework

## Implementation Details
- **CVFCollector class**: Inherits from `BasePDFCollector` to discover PDFs from CVF Open Access repository
- **URL Pattern Support**: Constructs URLs following pattern `https://openaccess.thecvf.com/{venue}{year}/papers/{paper}.pdf`
- **Proceedings Parsing**: Searches proceedings pages to find paper IDs by title with fuzzy matching (85% threshold)
- **Conference Validation**: Supports annual (CVPR, WACV) and biannual (ICCV-odd years, ECCV-even years) conferences
- **Caching**: Implements proceedings page caching to avoid redundant HTTP requests

## Testing
- Unit tests: 13 tests covering all functionality with 99% coverage
- Integration tests: 3 tests demonstrating framework integration
- All tests passing, code linted

## Test plan
- [ ] Run `uv run pytest tests/unit/pdf_discovery/test_cvf_collector.py -v` to verify unit tests
- [ ] Run `uv run pytest tests/integration/pdf_discovery/test_cvf_integration.py -v` to verify integration
- [ ] Test with real CVF papers to ensure scraping works correctly

Closes #87

🤖 Generated with [Claude Code](https://claude.ai/code)