### PR TITLE
[PDF-OpenAlex] Implement OpenAlex Integration

### DIFF
--- a/journals/issue_86_openalex_pdf_implementation.md
+++ b/journals/issue_86_openalex_pdf_implementation.md
@@ -1,0 +1,71 @@
+# Issue #86: OpenAlex PDF Discovery Implementation
+
+**Date**: 2025-07-02
+**Issue**: #86 - [PDF-OpenAlex] Implement OpenAlex Integration
+**Time Taken**: ~2 hours
+
+## Summary
+
+Successfully implemented OpenAlex integration for PDF discovery, allowing the system to find open access PDF URLs through OpenAlex's comprehensive academic database.
+
+## Implementation Details
+
+### 1. **OpenAlex PDF Collector** (`src/pdf_discovery/sources/openalex_collector.py`)
+- Extends `BasePDFCollector` following framework patterns
+- Supports both single and batch PDF discovery
+- Implements polite API access with email in User-Agent header
+- Rate limiting: 0.1s delay with email, 1.0s without
+- Retry logic for server errors (3 retries with exponential backoff)
+
+### 2. **Key Features**
+- **PDF URL Extraction**: Prioritizes `best_oa_location`, falls back to `primary_location`
+- **Institution Filtering**: Tracks Mila-affiliated papers using OpenAlex institution ID
+- **Batch Processing**: Efficiently queries up to 200 papers per API call
+- **License Tracking**: Extracts license information when available
+- **Confidence Scoring**: 0.9 for DOI matches, 0.8 for title searches
+
+### 3. **Testing**
+- **Unit Tests**: 12 comprehensive tests covering all functionality
+- **Integration Tests**: 4 tests verifying framework integration
+- All tests passing with good coverage
+
+### 4. **Integration**
+- Added to PDF discovery sources exports
+- Works seamlessly with existing PDF discovery framework
+- Compatible with deduplication engine
+
+## Technical Decisions
+
+1. **API Authentication**: Used email in User-Agent as recommended by OpenAlex for polite access
+2. **Batch Strategy**: Separate batch queries for DOI-identified papers, individual queries for title-only papers
+3. **Mila Institution ID**: Hardcoded as `https://openalex.org/I162448124` with option to override
+4. **Error Handling**: Graceful degradation with detailed logging
+
+## Key Code Locations
+
+- Collector: `src/pdf_discovery/sources/openalex_collector.py`
+- Unit Tests: `tests/unit/pdf_discovery/sources/test_openalex_collector.py`
+- Integration Tests: `tests/integration/pdf_discovery/test_openalex_integration.py`
+
+## Usage Example
+
+```python
+from src.pdf_discovery.sources.openalex_collector import OpenAlexPDFCollector
+from src.pdf_discovery import PDFDiscoveryFramework
+
+# Create collector with email for polite access
+collector = OpenAlexPDFCollector(email="researcher@example.com")
+
+# Add to framework
+framework = PDFDiscoveryFramework()
+framework.add_collector(collector)
+
+# Discover PDFs
+result = framework.discover_pdfs(papers)
+```
+
+## Next Steps
+
+- Monitor API usage and adjust rate limits if needed
+- Consider adding support for filtering by publication date
+- Potentially add caching for frequently queried papers

--- a/journals/issue_86_openalex_pdf_implementation_plan.md
+++ b/journals/issue_86_openalex_pdf_implementation_plan.md
@@ -1,0 +1,105 @@
+# Issue #86: OpenAlex PDF Discovery Implementation Plan
+
+**Date**: 2025-07-02
+**Issue**: #86 - [PDF-OpenAlex] Implement OpenAlex Integration
+**Time Estimate**: S (2-3h)
+
+## Summary
+
+This issue requires implementing OpenAlex integration for PDF discovery, using their API to find open access URLs for academic papers. The work involves creating a new PDF collector that integrates with the existing PDF discovery framework established in issues #77 and #78.
+
+## Current Codebase State
+
+### ✅ Prerequisites Met
+- **Issue #77** (Base PDF Discovery Framework) - CLOSED
+- **Issue #78** (Deduplication Engine) - CLOSED
+- Both dependencies are complete, providing the foundation for adding new sources
+
+### 📚 Existing Infrastructure
+
+1. **PDF Discovery Framework** (`package/src/pdf_discovery/`)
+   - `BasePDFCollector` abstract class that all sources must implement
+   - `PDFRecord` and `DiscoveryResult` models
+   - Parallel execution with progress tracking
+   - Framework orchestrates multiple collectors
+
+2. **Existing PDF Collectors**
+   - Semantic Scholar collector (good template for implementation)
+   - OpenReview, DOI Resolver, PMLR, PubMed Central
+   - All follow consistent pattern with rate limiting and error handling
+
+3. **OpenAlex Implementation** (`package/src/data/sources/`)
+   - `openalex.py` - Basic OpenAlex API client for citation collection
+   - `enhanced_openalex.py` - Enhanced version with better error handling
+   - **Note**: These are for citation collection, NOT PDF discovery
+
+### 🔧 What Needs Implementation
+
+1. **New OpenAlex PDF Collector**
+   - Create `package/src/pdf_discovery/sources/openalex_collector.py`
+   - Extend `BasePDFCollector` class
+   - Implement `_discover_single()` method
+   - Support batch operations (`supports_batch = True`)
+
+2. **Key OpenAlex API Fields**
+   - `primary_location.pdf_url` - Primary PDF location
+   - `best_oa_location.pdf_url` - Best open access PDF
+   - `locations[].pdf_url` - All available PDF URLs
+   - Institution filtering via `authorships[].institutions`
+
+3. **Implementation Pattern** (based on Semantic Scholar collector)
+   - API rate limiting (OpenAlex: 10 requests/second with API key)
+   - Retry logic for failed requests
+   - Confidence scoring based on match quality
+   - Batch processing for efficiency
+
+## Implementation Tasks
+
+1. **Create OpenAlex PDF Collector** [HIGH]
+   - Set up class structure following existing patterns
+   - Configure API client with rate limiting
+   - Implement paper lookup by DOI, title, and other identifiers
+
+2. **Implement Batch Lookup** [HIGH]
+   - Use OpenAlex batch API endpoints
+   - Handle pagination for large result sets
+   - Map responses back to original papers
+
+3. **Extract OA URLs** [HIGH]
+   - Parse `best_oa_location` and `primary_location` fields
+   - Handle multiple PDF URLs per paper
+   - Set appropriate confidence scores
+
+4. **Add Institution Filtering** [MEDIUM]
+   - Filter by Mila's institution ID in OpenAlex
+   - Prioritize Mila-authored papers
+   - Make filtering configurable
+
+5. **Write Tests** [MEDIUM]
+   - Unit tests for collector functionality
+   - Mock API responses
+   - Test error handling and rate limiting
+
+6. **Framework Integration** [MEDIUM]
+   - Add to PDF discovery framework initialization
+   - Update documentation
+   - Ensure proper registration with orchestrator
+
+## Technical Considerations
+
+- **API Key**: OpenAlex requires email in User-Agent or API key for polite access
+- **Rate Limits**: 10 requests/second with key, lower without
+- **Batch Size**: OpenAlex supports up to 200 works per request
+- **Institution ID**: Mila's OpenAlex ID needed for filtering
+
+## Success Criteria
+
+- Collector successfully discovers PDF URLs from OpenAlex
+- Batch processing works efficiently for large paper sets
+- Institution filtering properly prioritizes Mila papers
+- All tests pass with appropriate coverage
+- Integration with PDF discovery framework is seamless
+
+## Next Steps
+
+Begin implementation starting with the basic collector structure, following the patterns established by existing collectors like Semantic Scholar.

--- a/package/src/pdf_discovery/sources/__init__.py
+++ b/package/src/pdf_discovery/sources/__init__.py
@@ -5,6 +5,7 @@ from .venue_mappings import OPENREVIEW_VENUES, get_venue_invitation, is_venue_su
 from .pmlr_collector import PMLRCollector
 from .pubmed_central_collector import PubMedCentralCollector
 from .acl_anthology_collector import ACLAnthologyCollector
+from .openalex_collector import OpenAlexPDFCollector
 
 __all__ = [
     "OpenReviewPDFCollector",
@@ -13,5 +14,6 @@ __all__ = [
     "is_venue_supported",
     "PMLRCollector",
     "PubMedCentralCollector",
-    "ACLAnthologyCollector"
+    "ACLAnthologyCollector",
+    "OpenAlexPDFCollector"
 ]

--- a/package/src/pdf_discovery/sources/openalex_collector.py
+++ b/package/src/pdf_discovery/sources/openalex_collector.py
@@ -1,0 +1,371 @@
+"""OpenAlex PDF Collector for discovering open access PDFs."""
+
+import logging
+import time
+import os
+from typing import Dict, List, Optional
+from datetime import datetime
+import requests
+
+from src.pdf_discovery.core.collectors import BasePDFCollector
+from src.pdf_discovery.core.models import PDFRecord
+from src.data.models import Paper
+
+logger = logging.getLogger(__name__)
+
+# Module-level constants
+OPENALEX_BASE_URL = "https://api.openalex.org"
+OPENALEX_MAX_BATCH_SIZE = 200  # Maximum works per request
+DEFAULT_MAX_RETRIES = 3
+CONFIDENCE_SCORE_WITH_IDENTIFIER = 0.9  # Found via DOI or other identifier
+CONFIDENCE_SCORE_TITLE_SEARCH = 0.8  # Found via title search
+MILA_INSTITUTION_ID = "https://openalex.org/I162448124"  # Mila's OpenAlex ID
+
+
+class OpenAlexPDFCollector(BasePDFCollector):
+    """Collects PDF URLs from OpenAlex's open access fields."""
+    
+    def __init__(self, email: Optional[str] = None, mila_institution_id: Optional[str] = None):
+        """Initialize the OpenAlex PDF collector.
+        
+        Args:
+            email: Email for polite API access (recommended by OpenAlex)
+            mila_institution_id: OpenAlex institution ID for Mila filtering
+        """
+        super().__init__("openalex")
+        
+        # API configuration
+        self.email = email or os.getenv('OPENALEX_EMAIL')
+        self.base_url = OPENALEX_BASE_URL
+        
+        # Set up headers with User-Agent
+        self.headers = {
+            'User-Agent': 'PDF-Discovery-Framework/1.0'
+        }
+        if self.email:
+            self.headers['User-Agent'] += f' (mailto:{self.email})'
+        
+        # Batch settings
+        self.supports_batch = True
+        self.batch_size = OPENALEX_MAX_BATCH_SIZE
+        
+        # Rate limiting - OpenAlex recommends 10 requests/second with polite access
+        self.rate_limit_delay = 0.1 if self.email else 1.0
+        self.last_request_time = 0
+        
+        # Retry settings
+        self.max_retries = DEFAULT_MAX_RETRIES
+        self.retry_delay = 1.0
+        
+        # Institution filtering
+        self.mila_institution_id = mila_institution_id or MILA_INSTITUTION_ID
+        
+        logger.info(f"Initialized OpenAlex PDF collector "
+                   f"{'with' if self.email else 'without'} email for polite access")
+    
+    def _enforce_rate_limit(self):
+        """Enforce rate limiting between API requests."""
+        current_time = time.time()
+        elapsed = current_time - self.last_request_time
+        
+        if elapsed < self.rate_limit_delay:
+            sleep_time = self.rate_limit_delay - elapsed
+            logger.debug(f"Rate limiting: sleeping for {sleep_time:.2f}s")
+            time.sleep(sleep_time)
+        
+        self.last_request_time = time.time()
+    
+    def _build_filter_query(self, paper: Paper) -> str:
+        """Build OpenAlex filter query for paper search.
+        
+        Args:
+            paper: Paper to search for
+            
+        Returns:
+            OpenAlex filter string
+        """
+        filters = []
+        
+        # Try DOI first if available
+        if hasattr(paper, 'doi') and paper.doi:
+            # OpenAlex expects DOI without prefix
+            doi = paper.doi.replace('https://doi.org/', '')
+            filters.append(f'doi:{doi}')
+        else:
+            # Fall back to title search
+            # Escape special characters and use title.search for fuzzy matching
+            title = paper.title.replace('"', '\\"')
+            filters.append(f'title.search:"{title}"')
+        
+        return ','.join(filters)
+    
+    def _extract_pdf_url(self, work: dict) -> Optional[str]:
+        """Extract best available PDF URL from OpenAlex work.
+        
+        Args:
+            work: OpenAlex work object
+            
+        Returns:
+            PDF URL if available, None otherwise
+        """
+        # Prefer best_oa_location if available
+        best_oa = work.get('best_oa_location')
+        if best_oa and best_oa.get('pdf_url'):
+            return best_oa['pdf_url']
+        
+        # Fall back to primary_location
+        primary = work.get('primary_location', {})
+        if primary.get('is_oa') and primary.get('pdf_url'):
+            return primary['pdf_url']
+        
+        # Check all locations as last resort
+        locations = work.get('locations', [])
+        for location in locations:
+            if location.get('is_oa') and location.get('pdf_url'):
+                return location['pdf_url']
+        
+        return None
+    
+    def _extract_license(self, work: dict) -> Optional[str]:
+        """Extract license information from OpenAlex work.
+        
+        Args:
+            work: OpenAlex work object
+            
+        Returns:
+            License string if available
+        """
+        # Check best_oa_location first
+        best_oa = work.get('best_oa_location')
+        if best_oa and best_oa.get('license'):
+            return best_oa['license']
+        
+        # Check primary_location
+        primary = work.get('primary_location', {})
+        if primary.get('license'):
+            return primary['license']
+        
+        return None
+    
+    def _has_mila_author(self, work: dict) -> bool:
+        """Check if paper has at least one Mila-affiliated author.
+        
+        Args:
+            work: OpenAlex work object
+            
+        Returns:
+            True if has Mila author
+        """
+        if not self.mila_institution_id:
+            return False
+        
+        authorships = work.get('authorships', [])
+        for authorship in authorships:
+            institutions = authorship.get('institutions', [])
+            for institution in institutions:
+                if institution.get('id') == self.mila_institution_id:
+                    return True
+        
+        return False
+    
+    def _discover_single(self, paper: Paper) -> PDFRecord:
+        """Discover PDF for a single paper.
+        
+        Args:
+            paper: Paper to find PDF for
+            
+        Returns:
+            PDFRecord with discovered PDF information
+            
+        Raises:
+            ValueError: If no PDF is found
+            Exception: For API errors after retries
+        """
+        self._enforce_rate_limit()
+        
+        # Build search query
+        filter_query = self._build_filter_query(paper)
+        
+        # API parameters
+        params = {
+            'filter': filter_query,
+            'per-page': 10,  # Small limit for single search
+            'select': 'id,title,doi,best_oa_location,primary_location,locations,authorships'
+        }
+        
+        retries = 0
+        while retries < self.max_retries:
+            try:
+                response = requests.get(
+                    f"{self.base_url}/works",
+                    params=params,
+                    headers=self.headers,
+                    timeout=30
+                )
+                
+                if response.status_code == 200:
+                    data = response.json()
+                    results = data.get('results', [])
+                    
+                    if not results:
+                        raise ValueError(f"Paper not found in OpenAlex: {paper.title}")
+                    
+                    # Find best matching work (first result for now)
+                    work = results[0]
+                    
+                    # Extract PDF URL
+                    pdf_url = self._extract_pdf_url(work)
+                    if not pdf_url:
+                        raise ValueError(f"No PDF available for paper: {paper.title}")
+                    
+                    # Determine confidence based on search method
+                    has_identifier = hasattr(paper, 'doi') and paper.doi
+                    confidence_score = (
+                        CONFIDENCE_SCORE_WITH_IDENTIFIER if has_identifier 
+                        else CONFIDENCE_SCORE_TITLE_SEARCH
+                    )
+                    
+                    # Extract additional metadata
+                    openalex_id = work.get('id', '')
+                    license_info = self._extract_license(work)
+                    has_mila_author = self._has_mila_author(work)
+                    
+                    return PDFRecord(
+                        paper_id=paper.paper_id,
+                        pdf_url=pdf_url,
+                        source=self.source_name,
+                        discovery_timestamp=datetime.now(),
+                        confidence_score=confidence_score,
+                        version_info={
+                            'openalex_id': openalex_id,
+                            'has_mila_author': has_mila_author
+                        },
+                        validation_status='available',
+                        file_size_bytes=None,
+                        license=license_info
+                    )
+                
+                elif response.status_code == 429:
+                    # Rate limit
+                    retry_after = int(response.headers.get('Retry-After', 60))
+                    logger.warning(f"OpenAlex rate limit hit, retry after {retry_after}s")
+                    raise Exception(f"OpenAlex rate limit: retry after {retry_after}s")
+                
+                elif response.status_code >= 500:
+                    # Server error - retry
+                    retries += 1
+                    if retries >= self.max_retries:
+                        raise Exception(f"OpenAlex server error: {response.status_code}")
+                    
+                    wait_time = self.retry_delay * (2 ** (retries - 1))
+                    logger.warning(f"OpenAlex server error {response.status_code}, "
+                                 f"retry {retries}/{self.max_retries} in {wait_time}s")
+                    time.sleep(wait_time)
+                    continue
+                
+                else:
+                    # Client error
+                    raise Exception(f"OpenAlex API error: {response.status_code} - {response.text}")
+                
+            except requests.exceptions.RequestException as e:
+                retries += 1
+                if retries >= self.max_retries:
+                    logger.error(f"OpenAlex request failed after {self.max_retries} retries: {e}")
+                    raise
+                
+                wait_time = self.retry_delay * (2 ** (retries - 1))
+                logger.warning(f"OpenAlex request error (retry {retries}/{self.max_retries}): {e}")
+                time.sleep(wait_time)
+        
+        raise Exception(f"Failed to query OpenAlex after {self.max_retries} retries")
+    
+    def discover_pdfs_batch(self, papers: List[Paper]) -> Dict[str, PDFRecord]:
+        """Discover PDFs for multiple papers using batch API.
+        
+        Args:
+            papers: List of papers to discover PDFs for
+            
+        Returns:
+            Dictionary mapping paper_id to PDFRecord for successful discoveries
+        """
+        if not papers:
+            return {}
+        
+        logger.info(f"Starting batch PDF discovery for {len(papers)} papers")
+        results = {}
+        
+        # Process in batches
+        for i in range(0, len(papers), self.batch_size):
+            batch = papers[i:i + self.batch_size]
+            self._enforce_rate_limit()
+            
+            # Build batch filter query
+            doi_filters = []
+            doi_to_paper = {}  # Map DOI to paper for result matching
+            title_papers = []  # Papers without DOI
+            
+            for paper in batch:
+                if hasattr(paper, 'doi') and paper.doi:
+                    doi = paper.doi.replace('https://doi.org/', '')
+                    doi_filters.append(f'doi:{doi}')
+                    doi_to_paper[doi] = paper
+                else:
+                    title_papers.append(paper)
+            
+            # First, batch query by DOIs if any
+            if doi_filters:
+                # OpenAlex uses | for OR within a single filter
+                filter_query = '|'.join(doi_filters)  
+                params = {
+                    'filter': filter_query,  # Already includes doi: prefix for each DOI
+                    'per-page': len(doi_filters),
+                    'select': 'id,title,doi,best_oa_location,primary_location,locations,authorships'
+                }
+                
+                try:
+                    response = requests.get(
+                        f"{self.base_url}/works",
+                        params=params,
+                        headers=self.headers,
+                        timeout=30
+                    )
+                    
+                    if response.status_code == 200:
+                        data = response.json()
+                        for work in data.get('results', []):
+                            # Match work to paper by DOI
+                            work_doi = work.get('doi', '').replace('https://doi.org/', '')
+                            if work_doi in doi_to_paper:
+                                paper = doi_to_paper[work_doi]
+                                pdf_url = self._extract_pdf_url(work)
+                                
+                                if pdf_url:
+                                    pdf_record = PDFRecord(
+                                        paper_id=paper.paper_id,
+                                        pdf_url=pdf_url,
+                                        source=self.source_name,
+                                        discovery_timestamp=datetime.now(),
+                                        confidence_score=CONFIDENCE_SCORE_WITH_IDENTIFIER,
+                                        version_info={
+                                            'openalex_id': work.get('id', ''),
+                                            'has_mila_author': self._has_mila_author(work)
+                                        },
+                                        validation_status='available',
+                                        file_size_bytes=None,
+                                        license=self._extract_license(work)
+                                    )
+                                    results[paper.paper_id] = pdf_record
+                
+                except Exception as e:
+                    logger.error(f"Batch DOI query failed: {e}")
+            
+            # Process papers without DOI individually
+            for paper in title_papers:
+                try:
+                    pdf_record = self._discover_single(paper)
+                    results[paper.paper_id] = pdf_record
+                except Exception as e:
+                    logger.debug(f"Failed to discover PDF for {paper.paper_id}: {e}")
+        
+        logger.info(f"Batch discovery complete: found {len(results)}/{len(papers)} PDFs")
+        return results

--- a/package/tests/integration/pdf_discovery/test_openalex_integration.py
+++ b/package/tests/integration/pdf_discovery/test_openalex_integration.py
@@ -1,0 +1,205 @@
+"""Integration tests for OpenAlex PDF discovery."""
+
+import pytest
+import os
+from datetime import datetime
+from unittest.mock import patch, Mock
+
+from src.pdf_discovery.sources.openalex_collector import OpenAlexPDFCollector
+from src.pdf_discovery import PDFDiscoveryFramework
+from src.data.models import Paper, Author
+
+
+class TestOpenAlexIntegration:
+    """Integration tests for OpenAlex PDF collector."""
+    
+    @pytest.fixture
+    def sample_papers(self):
+        """Create sample papers for testing."""
+        papers = [
+            Paper(
+                paper_id="paper_1",
+                title="Neural Network Optimization",
+                authors=[Author(name="Jane Doe", affiliation="Mila")],
+                year=2023,
+                venue="NeurIPS",
+                doi="10.1234/neurips.2023.001",
+                citations=15
+            ),
+            Paper(
+                paper_id="paper_2", 
+                title="Transformer Architecture Improvements",
+                authors=[Author(name="John Smith", affiliation="University of Montreal")],
+                year=2023,
+                venue="ICML",
+                doi="10.1234/icml.2023.002",
+                citations=25
+            ),
+            Paper(
+                paper_id="paper_3",
+                title="Reinforcement Learning in Robotics",
+                authors=[Author(name="Alice Johnson", affiliation="Mila")],
+                year=2023,
+                venue="ICLR",
+                arxiv_id="2301.12345",
+                citations=10
+            )
+        ]
+        return papers
+    
+    @patch.dict(os.environ, {"OPENALEX_EMAIL": "test@example.com"})
+    def test_collector_initialization(self):
+        """Test collector can be initialized with environment variable."""
+        collector = OpenAlexPDFCollector()
+        assert collector.email == "test@example.com"
+        assert collector.source_name == "openalex"
+        assert collector.supports_batch is True
+    
+    @patch('requests.get')
+    def test_framework_integration(self, mock_get, sample_papers):
+        """Test OpenAlex collector integration with PDF discovery framework."""
+        # Mock OpenAlex API responses
+        mock_responses = {
+            "10.1234/neurips.2023.001": {
+                "id": "https://openalex.org/W1111111111",
+                "doi": "https://doi.org/10.1234/neurips.2023.001",
+                "best_oa_location": {
+                    "is_oa": True,
+                    "pdf_url": "https://papers.neurips.cc/paper/2023/file/paper1.pdf",
+                    "license": "cc-by"
+                },
+                "authorships": [
+                    {"institutions": [{"id": "https://openalex.org/I162448124", "display_name": "Mila"}]}
+                ]
+            },
+            "10.1234/icml.2023.002": {
+                "id": "https://openalex.org/W2222222222",
+                "doi": "https://doi.org/10.1234/icml.2023.002",
+                "primary_location": {
+                    "is_oa": True,
+                    "pdf_url": "https://proceedings.mlr.press/v202/paper2.pdf"
+                },
+                "best_oa_location": None,
+                "authorships": []
+            }
+        }
+        
+        def mock_api_response(url, params=None, headers=None, timeout=None):
+            """Mock OpenAlex API responses."""
+            response = Mock()
+            
+            # Extract DOI from filter parameter
+            filter_param = params.get('filter', '')
+            
+            # Handle batch query
+            if 'doi:10.1234/neurips.2023.001|doi:10.1234/icml.2023.002' in filter_param:
+                response.status_code = 200
+                response.json.return_value = {
+                    "results": list(mock_responses.values()),
+                    "meta": {"count": 2}
+                }
+            # Handle individual queries
+            elif 'doi:10.1234/neurips.2023.001' in filter_param:
+                response.status_code = 200
+                response.json.return_value = {
+                    "results": [mock_responses["10.1234/neurips.2023.001"]],
+                    "meta": {"count": 1}
+                }
+            elif 'doi:10.1234/icml.2023.002' in filter_param:
+                response.status_code = 200
+                response.json.return_value = {
+                    "results": [mock_responses["10.1234/icml.2023.002"]],
+                    "meta": {"count": 1}
+                }
+            else:
+                # No results for other queries
+                response.status_code = 200
+                response.json.return_value = {
+                    "results": [],
+                    "meta": {"count": 0}
+                }
+            
+            return response
+        
+        mock_get.side_effect = mock_api_response
+        
+        # Create framework and add OpenAlex collector
+        framework = PDFDiscoveryFramework()
+        openalex_collector = OpenAlexPDFCollector(email="test@example.com")
+        framework.add_collector(openalex_collector)
+        
+        # Discover PDFs
+        result = framework.discover_pdfs(sample_papers)
+        
+        # Verify results
+        assert result.total_papers == 3
+        assert result.discovered_count == 2  # Only 2 papers have PDFs
+        assert len(result.records) == 2
+        
+        # Check specific records
+        pdf_urls = {record.paper_id: record.pdf_url for record in result.records}
+        assert pdf_urls["paper_1"] == "https://papers.neurips.cc/paper/2023/file/paper1.pdf"
+        assert pdf_urls["paper_2"] == "https://proceedings.mlr.press/v202/paper2.pdf"
+        
+        # Check Mila affiliation tracking
+        mila_paper = next(r for r in result.records if r.paper_id == "paper_1")
+        assert mila_paper.version_info["has_mila_author"] is True
+        
+        # Check statistics
+        assert "openalex" in result.source_statistics
+        assert result.source_statistics["openalex"]["attempted"] == 3
+        assert result.source_statistics["openalex"]["successful"] == 2
+    
+    def test_mila_institution_filtering(self):
+        """Test Mila institution ID configuration."""
+        # Test with custom Mila ID
+        collector = OpenAlexPDFCollector(mila_institution_id="https://openalex.org/I999999999")
+        assert collector.mila_institution_id == "https://openalex.org/I999999999"
+        
+        # Test with default Mila ID
+        collector_default = OpenAlexPDFCollector()
+        assert collector_default.mila_institution_id == "https://openalex.org/I162448124"
+    
+    @patch('requests.get')
+    def test_concurrent_discovery(self, mock_get, sample_papers):
+        """Test OpenAlex works with concurrent discovery."""
+        # Mock successful responses for all papers
+        def mock_response(url, params=None, headers=None, timeout=None):
+            response = Mock()
+            response.status_code = 200
+            response.json.return_value = {
+                "results": [{
+                    "id": "https://openalex.org/W123",
+                    "best_oa_location": {
+                        "is_oa": True,
+                        "pdf_url": "https://example.com/paper.pdf"
+                    },
+                    "authorships": []
+                }],
+                "meta": {"count": 1}
+            }
+            return response
+        
+        mock_get.side_effect = mock_response
+        
+        # Create framework with multiple collectors
+        framework = PDFDiscoveryFramework()
+        framework.add_collector(OpenAlexPDFCollector())
+        
+        # Mock another collector
+        mock_collector = Mock()
+        mock_collector.source_name = "mock_source"
+        mock_collector.supports_batch = False
+        mock_collector.discover_pdfs_batch.return_value = {}
+        framework.add_collector(mock_collector)
+        
+        # Discover with progress callback
+        progress_updates = []
+        def progress_callback(current, total, message):
+            progress_updates.append((current, total, message))
+        
+        result = framework.discover_pdfs(sample_papers[:1], progress_callback=progress_callback)
+        
+        # Verify concurrent execution
+        assert result.discovered_count >= 0
+        assert len(progress_updates) > 0

--- a/package/tests/unit/pdf_discovery/sources/test_openalex_collector.py
+++ b/package/tests/unit/pdf_discovery/sources/test_openalex_collector.py
@@ -1,0 +1,320 @@
+"""Unit tests for OpenAlex PDF Collector."""
+
+import pytest
+from unittest.mock import Mock, patch, MagicMock
+from datetime import datetime
+import time
+
+from src.pdf_discovery.sources.openalex_collector import OpenAlexPDFCollector
+from src.pdf_discovery.core.models import PDFRecord
+from src.data.models import Paper
+
+
+class TestOpenAlexPDFCollector:
+    """Test OpenAlex PDF collector functionality."""
+    
+    @pytest.fixture
+    def collector(self):
+        """Create collector instance."""
+        return OpenAlexPDFCollector(email="test@example.com")
+    
+    @pytest.fixture
+    def mock_paper(self):
+        """Create a mock paper."""
+        paper = Mock(spec=Paper)
+        paper.paper_id = "test_123"
+        paper.title = "Test Paper Title"
+        paper.doi = "10.1234/test"
+        paper.authors = ["Author One", "Author Two"]
+        paper.year = 2023
+        return paper
+    
+    @pytest.fixture
+    def openalex_work_with_pdf(self):
+        """Mock OpenAlex work response with PDF."""
+        return {
+            "id": "https://openalex.org/W1234567890",
+            "title": "Test Paper Title",
+            "doi": "https://doi.org/10.1234/test",
+            "primary_location": {
+                "is_oa": True,
+                "pdf_url": "https://example.com/primary.pdf",
+                "license": "cc-by"
+            },
+            "best_oa_location": {
+                "is_oa": True,
+                "pdf_url": "https://example.com/best_oa.pdf",
+                "license": "cc-by"
+            },
+            "authorships": [
+                {
+                    "author": {"display_name": "Author One"},
+                    "institutions": [
+                        {"id": "https://openalex.org/I162448124", "display_name": "Mila"}
+                    ]
+                }
+            ]
+        }
+    
+    @pytest.fixture
+    def openalex_work_without_pdf(self):
+        """Mock OpenAlex work response without PDF."""
+        return {
+            "id": "https://openalex.org/W9876543210",
+            "title": "Test Paper Without PDF",
+            "doi": "https://doi.org/10.1234/test2",
+            "primary_location": {
+                "is_oa": False,
+                "pdf_url": None
+            },
+            "best_oa_location": None
+        }
+    
+    def test_initialization(self, collector):
+        """Test collector initialization."""
+        assert collector.source_name == "openalex"
+        assert collector.email == "test@example.com"
+        assert collector.supports_batch is True
+        assert collector.batch_size == 200  # OpenAlex max
+        assert "mailto:test@example.com" in collector.headers["User-Agent"]
+    
+    def test_initialization_without_email(self):
+        """Test collector initialization without email."""
+        collector = OpenAlexPDFCollector()
+        assert collector.email is None
+        assert "mailto:" not in collector.headers["User-Agent"]
+    
+    @patch('requests.get')
+    def test_discover_single_with_pdf(self, mock_get, collector, mock_paper, openalex_work_with_pdf):
+        """Test discovering PDF for a single paper."""
+        # Mock successful API response
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "results": [openalex_work_with_pdf],
+            "meta": {"count": 1}
+        }
+        mock_get.return_value = mock_response
+        
+        # Discover PDF
+        pdf_record = collector._discover_single(mock_paper)
+        
+        # Verify result
+        assert isinstance(pdf_record, PDFRecord)
+        assert pdf_record.paper_id == "test_123"
+        assert pdf_record.pdf_url == "https://example.com/best_oa.pdf"
+        assert pdf_record.source == "openalex"
+        assert pdf_record.confidence_score == 0.9  # Found by DOI
+        assert pdf_record.license == "cc-by"
+        assert pdf_record.version_info["openalex_id"] == "https://openalex.org/W1234567890"
+    
+    @patch('requests.get')
+    def test_discover_single_without_pdf(self, mock_get, collector, mock_paper, openalex_work_without_pdf):
+        """Test handling paper without available PDF."""
+        # Mock API response without PDF
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "results": [openalex_work_without_pdf],
+            "meta": {"count": 1}
+        }
+        mock_get.return_value = mock_response
+        
+        # Should raise ValueError
+        with pytest.raises(ValueError, match="No PDF available"):
+            collector._discover_single(mock_paper)
+    
+    @patch('requests.get')
+    def test_discover_single_paper_not_found(self, mock_get, collector, mock_paper):
+        """Test handling paper not found in OpenAlex."""
+        # Mock empty response
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "results": [],
+            "meta": {"count": 0}
+        }
+        mock_get.return_value = mock_response
+        
+        # Should raise ValueError
+        with pytest.raises(ValueError, match="Paper not found"):
+            collector._discover_single(mock_paper)
+    
+    @patch('requests.get')
+    def test_discover_single_by_title(self, mock_get, collector, openalex_work_with_pdf):
+        """Test discovering PDF by title search when no DOI."""
+        # Create paper without DOI
+        paper = Mock(spec=Paper)
+        paper.paper_id = "test_456"
+        paper.title = "Test Paper Title"
+        paper.doi = None
+        paper.authors = ["Author One"]
+        
+        # Mock API response
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "results": [openalex_work_with_pdf],
+            "meta": {"count": 1}
+        }
+        mock_get.return_value = mock_response
+        
+        # Discover PDF
+        pdf_record = collector._discover_single(paper)
+        
+        # Verify result
+        assert pdf_record.paper_id == "test_456"
+        assert pdf_record.confidence_score == 0.8  # Found by title
+        
+        # Check that title search was used
+        call_args = mock_get.call_args
+        assert "filter" in call_args[1]["params"]
+        assert "title.search" in call_args[1]["params"]["filter"]
+    
+    @patch('requests.get')
+    def test_rate_limiting(self, mock_get, collector, mock_paper, openalex_work_with_pdf):
+        """Test rate limiting between requests."""
+        # Mock successful responses
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "results": [openalex_work_with_pdf],
+            "meta": {"count": 1}
+        }
+        mock_get.return_value = mock_response
+        
+        # Make two rapid requests
+        start_time = time.time()
+        collector._discover_single(mock_paper)
+        collector._discover_single(mock_paper)
+        elapsed = time.time() - start_time
+        
+        # Should have delayed between requests
+        assert elapsed >= collector.rate_limit_delay
+    
+    @patch('requests.get')
+    def test_batch_discovery(self, mock_get, collector, openalex_work_with_pdf):
+        """Test batch PDF discovery."""
+        # Create multiple papers
+        papers = []
+        for i in range(3):
+            paper = Mock(spec=Paper)
+            paper.paper_id = f"test_{i}"
+            paper.title = f"Test Paper {i}"
+            paper.doi = f"10.1234/test{i}"
+            papers.append(paper)
+        
+        # Create unique responses for each paper
+        results_data = []
+        for i in range(3):
+            work = dict(openalex_work_with_pdf)
+            work['doi'] = f"https://doi.org/10.1234/test{i}"
+            results_data.append(work)
+        
+        # Mock batch API response
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "results": results_data,
+            "meta": {"count": 3}
+        }
+        mock_get.return_value = mock_response
+        
+        # Discover PDFs in batch
+        results = collector.discover_pdfs_batch(papers)
+        
+        # Verify results
+        assert len(results) == 3
+        for i, paper in enumerate(papers):
+            assert paper.paper_id in results
+            assert results[paper.paper_id].pdf_url == "https://example.com/best_oa.pdf"
+    
+    @patch('requests.get')
+    def test_retry_on_server_error(self, mock_get, collector, mock_paper, openalex_work_with_pdf):
+        """Test retry logic on server errors."""
+        # First two calls fail, third succeeds
+        mock_responses = []
+        
+        # Server error response
+        error_response = Mock()
+        error_response.status_code = 500
+        mock_responses.extend([error_response, error_response])
+        
+        # Success response
+        success_response = Mock()
+        success_response.status_code = 200
+        success_response.json.return_value = {
+            "results": [openalex_work_with_pdf],
+            "meta": {"count": 1}
+        }
+        mock_responses.append(success_response)
+        
+        mock_get.side_effect = mock_responses
+        
+        # Should succeed after retries
+        pdf_record = collector._discover_single(mock_paper)
+        assert pdf_record.pdf_url == "https://example.com/best_oa.pdf"
+        assert mock_get.call_count == 3
+    
+    @patch('requests.get')
+    def test_handle_rate_limit(self, mock_get, collector, mock_paper):
+        """Test handling rate limit responses."""
+        # Mock rate limit response
+        mock_response = Mock()
+        mock_response.status_code = 429
+        mock_response.headers = {"Retry-After": "2"}
+        mock_get.return_value = mock_response
+        
+        # Should raise exception after handling
+        with pytest.raises(Exception, match="rate limit"):
+            collector._discover_single(mock_paper)
+    
+    def test_extract_best_pdf_url(self, collector, openalex_work_with_pdf):
+        """Test PDF URL extraction logic."""
+        # Should prefer best_oa_location
+        url = collector._extract_pdf_url(openalex_work_with_pdf)
+        assert url == "https://example.com/best_oa.pdf"
+        
+        # Test with only primary_location
+        work = {
+            "primary_location": {
+                "is_oa": True,
+                "pdf_url": "https://example.com/primary.pdf"
+            },
+            "best_oa_location": None
+        }
+        url = collector._extract_pdf_url(work)
+        assert url == "https://example.com/primary.pdf"
+        
+        # Test with no PDF
+        work = {"primary_location": {"is_oa": False}, "best_oa_location": None}
+        assert collector._extract_pdf_url(work) is None
+    
+    def test_institution_filtering(self, collector):
+        """Test Mila institution filtering."""
+        # Enable Mila filtering
+        collector.mila_institution_id = "https://openalex.org/I162448124"
+        
+        # Paper with Mila author
+        work_mila = {
+            "authorships": [
+                {
+                    "institutions": [
+                        {"id": "https://openalex.org/I162448124", "display_name": "Mila"}
+                    ]
+                }
+            ]
+        }
+        assert collector._has_mila_author(work_mila) is True
+        
+        # Paper without Mila author
+        work_other = {
+            "authorships": [
+                {
+                    "institutions": [
+                        {"id": "https://openalex.org/I999999999", "display_name": "Other"}
+                    ]
+                }
+            ]
+        }
+        assert collector._has_mila_author(work_other) is False


### PR DESCRIPTION
## Summary
- Implemented OpenAlex PDF discovery integration for finding open access URLs
- Added batch processing support for efficient paper lookup (up to 200 papers per request)
- Integrated Mila institution filtering using OpenAlex institution ID

## Implementation Details

### OpenAlex PDF Collector
- Created `OpenAlexPDFCollector` class extending `BasePDFCollector`
- Supports polite API access with email authentication in User-Agent header
- Implements rate limiting (0.1s with email, 1.0s without)
- Includes retry logic for server errors with exponential backoff

### Key Features
- **PDF URL Extraction**: Uses `best_oa_location` and `primary_location` fields
- **Batch Processing**: Efficiently queries multiple papers in single API calls
- **Institution Filtering**: Tracks Mila-affiliated papers (ID: I162448124)
- **Confidence Scoring**: 0.9 for DOI matches, 0.8 for title searches
- **License Tracking**: Extracts license information when available

### Testing
- 12 comprehensive unit tests covering all functionality
- 4 integration tests verifying framework integration
- All tests passing with good coverage

## Test Plan
- [x] Unit tests for single paper discovery
- [x] Unit tests for batch discovery
- [x] Integration tests with PDF discovery framework
- [x] Rate limiting and error handling tests
- [x] Institution filtering tests

Closes #86

🤖 Generated with [Claude Code](https://claude.ai/code)