### PR TITLE
Fix extraction module test failures

### DIFF
--- a/journals/issue_162_extraction_test_fixes.md
+++ b/journals/issue_162_extraction_test_fixes.md
@@ -1,0 +1,35 @@
+# Issue #162: Fix Extraction Module Test Failures
+
+**Date**: 2025-07-08
+**Author**: Claude
+
+## Summary
+
+Fixed 4 test failures in the extraction module's `test_extraction_protocol.py` file identified in PR #139.
+
+## Issues Fixed
+
+### 1. Time Tracking (test_phase1_preparation & test_run_full_protocol)
+**Problem**: `time_spent_minutes` was 0 because phase durations under 1 minute were converted to 0 using `int()`
+**Solution**: Used `math.ceil()` to round up and ensure minimum 1 minute is recorded: `max(1, math.ceil(phase_duration))`
+
+### 2. Completeness Score Calculation (test_calculate_completeness_score)
+**Problem**: Default values like `parameters_unit="millions"` and `number_of_runs=1` were counted as filled fields
+**Solution**: Added logic to exclude specific default values from the completeness calculation
+
+### 3. Mock Analyzer Attributes (test_missing_analyzer_attributes)
+**Problem**: `getattr()` on Mock objects returns another Mock instead of the default value
+**Solution**: Added explicit check for attribute existence and non-callable nature before using `getattr()`
+
+## Code Changes
+
+1. Added `import math` for ceiling function
+2. Updated all phase timing calculations to use `max(1, math.ceil(phase_duration))`
+3. Modified `_calculate_completeness_score()` to exclude default values
+4. Enhanced `phase2_automated_extraction()` to properly handle Mock objects
+
+## Results
+
+- All 32 tests in `test_extraction_protocol.py` now pass
+- Code passes linting checks
+- No regression in existing tests


### PR DESCRIPTION
## Summary
- Fixed 4 test failures in the extraction module identified in PR #139
- All tests in `test_extraction_protocol.py` now pass

## Changes
1. **Time tracking**: Changed from `int()` to `math.ceil()` with minimum 1 minute to ensure time is always recorded
2. **Completeness score**: Excluded default values (`parameters_unit="millions"`, `number_of_runs=1`) from filled field count
3. **Mock analyzer**: Added proper handling to avoid Mock objects being returned instead of default values

## Test Results
- All 32 tests in `test_extraction_protocol.py` pass
- Code passes linting checks
- No regression in existing tests

Fixes #162

🤖 Generated with [Claude Code](https://claude.ai/code)