### PR TITLE
Fix Package Configuration Test Failures

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "compute-forecast"
 version = "0.1.0"
 description = "A comprehensive tool for analyzing and forecasting computational requirements in machine learning research"
 readme = "README.md"
-requires-python = ">=3.12"
+requires-python = "==3.12.*"
 license = {text = "MIT"}
 authors = [
     {name = "Compute Forecast Team", email = "compute-forecast@example.com"}
@@ -20,7 +20,6 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.12",
-    "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
     "pyyaml>=6.0.2",


### PR DESCRIPTION
## Summary
- Fixed Python version constraint from `>=3.12` to `==3.12.*` in pyproject.toml
- Removed Python 3.13 classifier to match project's Python 3.12-only support
- Updated virtual environment to use Python 3.12.3 instead of 3.13.2

## Test Results
All package configuration tests now pass:
- ✅ `test_python_version_requirement` - Version constraint now matches expected `==3.12.*`
- ✅ `test_python_classifiers` - Removed extra Python 3.13 classifier
- ✅ `test_current_python_version` - Tests now run on Python 3.12.3

## Changes Made
1. **pyproject.toml:10** - Changed `requires-python = ">=3.12"` to `requires-python = "==3.12.*"`
2. **pyproject.toml:23** - Removed `"Programming Language :: Python :: 3.13"` classifier
3. **Virtual Environment** - Recreated with Python 3.12.3 for consistency

## Verification
- Configuration now consistent across pyproject.toml, tests, and CI workflow
- All 3 failing tests identified in issue #166 now pass
- Python version restriction aligns with project's CI configuration

🤖 Generated with [Claude Code](https://claude.ai/code)